### PR TITLE
Add AWS ID Generator and Propagator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,16 @@
     "description": "The contributor repo for opentelemetry-php",
     "type": "library",
     "license": "Apache-2.0",
+    "repositories": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/open-telemetry/opentelemetry-php"
+        }
+      ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "open-telemetry/opentelemetry": "dev-main"
     },
     "authors": [
         {

--- a/instrumentation/aws/xray/AwsXrayIdGenerator.php
+++ b/instrumentation/aws/xray/AwsXrayIdGenerator.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Instrumentation\Aws\Xray;
+
+use OpenTelemetry\Sdk\Trace\IdGenerator;
+use OpenTelemetry\Sdk\Trace\RandomIdGenerator;
+
+/**
+ * An ID generator that generates trace IDs that conforms to AWS X-Ray format
+ * Refer to the AWS X-Ray documentation:
+ * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
+ */
+class AwsXrayIdGenerator implements IdGenerator
+{
+    private const TRACE_ID_RANDOM_HEX_LENGTH = 24;
+
+    /**
+     * Constructor creates randomIdGenerator instance
+     */
+    public function __construct()
+    {
+        $this->randomIdGenerator = new RandomIdGenerator();
+    }
+
+    /**
+     * Returns a trace ID in AWS X-Ray format.
+     * Dashes and version number are done in inject() function of Propagator
+     *
+     * Returns an epoch timestamp converted to
+     * 8 hexadecimal digits, and random 96-bit string converted to a
+     * 24 character hexadecimal string in one 32 character string.
+     *
+     * Example: 60cd399d76b435b5411c66f29b238014
+     */
+    public function generateTraceId(): string
+    {
+        return dechex(time()) . $this->randomIdGenerator->randomHex(self::TRACE_ID_RANDOM_HEX_LENGTH);
+    }
+
+    /**
+     * Returns a random 64-bit string in the form of 16
+     * hexadecimal characters.
+     */
+    public function generateSpanId(): string
+    {
+        return $this->randomIdGenerator->generateSpanId();
+    }
+}

--- a/propagators/aws/xray/Propagator.php
+++ b/propagators/aws/xray/Propagator.php
@@ -1,0 +1,162 @@
+<?php
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Propagators\Aws\Xray;
+
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Trace as API;
+
+/**
+ * Implementation of AWS Trace Header Protocol
+ * See below:
+ * https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+ *
+ * Propagator serializes Span Context to/from AWS X-Ray headers.
+ * Example AWS X-Ray format:
+ *
+ * X-Amzn-Trace-Id: Root={traceId};Parent={parentId};Sampled={samplingFlag}
+ * X-Amzn-Trace-Id: Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1
+ */
+class AwsXrayPropagator implements API\TextMapFormatPropagator
+{
+    public const AWSXRAY_TRACE_ID_HEADER = 'X-Amzn-Trace-Id';
+    private const HEADER_TYPE = 'string';
+    private const VERSION_NUMBER = '1';
+    private const TRACE_HEADER_DELIMITER = ';';
+    private const KV_DELIMITER = '=';
+
+    private const TRACE_ID_KEY = 'Root';
+    private const TRACE_ID_LENGTH = 32;
+    private const TRACE_ID_VERSION = '1';
+    private const TRACE_ID_DELIMITER = '-';
+    private const TRACE_ID_TIMESTAMP_LENGTH = 8;
+    private const VERSION_NUMBER_INDEX = 0;
+    private const TIMESTAMP_INDEX = 1;
+    private const RANDOM_HEX_INDEX = 2;
+
+    private const PARENT_ID_KEY = 'Parent';
+    private const SPAN_ID_LENGTH = 16;
+    
+    private const SAMPLED_FLAG_KEY = 'Sampled';
+    private const IS_SAMPLED = '1';
+    private const NOT_SAMPLED = '0';
+    
+    /**
+     * Returns list of fields used by HTTPTextFormat
+     */
+    public static function fields(): array
+    {
+        return [self::AWSXRAY_TRACE_ID_HEADER];
+    }
+
+    /**
+     * Creates and injects the traceHeader
+     * X-Amzn-Trace-Id: Root={traceId};Parent={parentId};Sampled={samplingFlag}
+     * X-Amzn-Trace-Id: Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1
+     */
+    public static function inject(API\SpanContext $context, &$carrier, API\PropagationSetter $setter): void
+    {
+        $traceId = $context->getTraceId();
+        $spanId = $context->getSpanId();
+
+        if (!SpanContext::isValidSpanId($spanId) || !SpanContext::isValidTraceId($traceId)) {
+            return;
+        }
+
+        $timestamp = substr($traceId, 0, self::TRACE_ID_TIMESTAMP_LENGTH);
+        $randomHex = substr($traceId, self::TRACE_ID_TIMESTAMP_LENGTH);
+        $samplingFlag = $context->isSampled() ? self::IS_SAMPLED : self::NOT_SAMPLED;
+
+        $traceHeader = self::TRACE_ID_KEY . self::KV_DELIMITER . self::VERSION_NUMBER .
+            self::TRACE_ID_DELIMITER . $timestamp . self::TRACE_ID_DELIMITER . $randomHex .
+            self::TRACE_HEADER_DELIMITER . self::PARENT_ID_KEY . self::KV_DELIMITER . $spanId .
+            self::TRACE_HEADER_DELIMITER . self::SAMPLED_FLAG_KEY . self::KV_DELIMITER . $samplingFlag;
+        $setter->set($carrier, self::AWSXRAY_TRACE_ID_HEADER, $traceHeader);
+    }
+
+    /**
+     * Extracts the span context from the carrier to transfer to the next service
+     * This function will parse all parts of the header and validate that it is
+     * formatted properly to AWS X-ray standards
+     */
+    public static function extract($carrier, API\PropagationGetter $getter): API\SpanContext
+    {
+        // Extract the traceHeader using the getter from the carrier
+        $traceHeader = $getter->get($carrier, self::AWSXRAY_TRACE_ID_HEADER);
+        
+        // If it is null it creates a dummy header with INVALID_TRACE and INVALID_SPAN
+        // Function: restore(string $traceId, string $spanId, bool $sampled = false,
+        // bool $isRemote = false, ?API\TraceState $traceState = null): SpanContext
+        if ($traceHeader == null || gettype($traceHeader) !== self::HEADER_TYPE) {
+            return SpanContext::getInvalid();
+        }
+
+        $headerComponents = explode(self::TRACE_HEADER_DELIMITER, $traceHeader);
+        $parsedTraceId = SpanContext::INVALID_TRACE;
+        $parsedSpanId = SpanContext::INVALID_SPAN;
+        $sampledFlag = '';
+
+        foreach ($headerComponents as $component) {
+            // The key value pair of a component of the traceHeader.
+            // Example: key = 'Parent' value = '53995c3f42cd8ad8'
+            $componentPair = explode(self::KV_DELIMITER, $component);
+
+            if ($componentPair[0] === self::PARENT_ID_KEY) {
+                $parsedSpanId = $componentPair[1];
+            } elseif ($componentPair[0] === self::TRACE_ID_KEY) {
+                $parsedTraceId = self::parseTraceId($componentPair[1]);
+            } elseif ($componentPair[0] === self::SAMPLED_FLAG_KEY) {
+                $sampledFlag = $componentPair[1];
+            }
+        }
+
+        if (SpanContext::isValidSpanId($parsedSpanId) && SpanContext::isValidTraceId($parsedTraceId) && self::isValidSampled($sampledFlag)) {
+            return SpanContext::restore($parsedTraceId, $parsedSpanId, $sampledFlag === self::IS_SAMPLED, true);
+        }
+
+        return SpanContext::getInvalid();
+    }
+
+    /**
+     * Parse Xray format trace Id
+     * Returns parsedId if successful, else returns invalid trace Id
+     */
+    private static function parseTraceId($traceId): string
+    {
+        $parsedTraceId = SpanContext::INVALID_TRACE;
+        $traceIdParts = explode(self::TRACE_ID_DELIMITER, $traceId);
+        if (count($traceIdParts) > 1 && SpanContext::isValidTraceId($traceIdParts[self::TIMESTAMP_INDEX] .
+        $traceIdParts[self::RANDOM_HEX_INDEX]) && $traceIdParts[self::VERSION_NUMBER_INDEX] === self::VERSION_NUMBER) {
+            $parsedTraceId = $traceIdParts[self::TIMESTAMP_INDEX] . $traceIdParts[self::RANDOM_HEX_INDEX];
+        }
+
+        return $parsedTraceId;
+    }
+
+    /**
+     * Checks whether the sampling decision is valid or not.
+     * Valid sampling decisions must be a 0 or 1 string
+     * This is AWS specific since it separates the sampled flag from  other trace flags
+     * This can be moved to SpanContext file at a later date if desired by other propagators
+     */
+    private static function isValidSampled($samplingFlag): bool
+    {
+        return $samplingFlag === self::IS_SAMPLED || $samplingFlag === self::NOT_SAMPLED;
+    }
+}

--- a/tests/unit/IdGeneratorTest.php
+++ b/tests/unit/IdGeneratorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Instrumentation\Aws\Xray\AwsXrayIdGenerator;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use PHPUnit\Framework\TestCase;
+
+class AwsXrayIdGeneratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function GeneratedTraceIdIsValid()
+    {
+        $idGenerator = new AwsXrayIdGenerator();
+        $traceId = $idGenerator->generateTraceId();
+
+        $this->assertEquals(1, preg_match(SpanContext::VALID_TRACE, $traceId));
+    }
+    
+    /**
+     * @test
+     */
+    public function GeneratedTraceIdIsUnique()
+    {
+        $idGenerator = new AwsXrayIdGenerator();
+        $traceId1 = $idGenerator->generateTraceId();
+        $traceId2 = $idGenerator->generateTraceId();
+
+        $this->assertFalse($traceId2 === $traceId1);
+    }
+
+    /**
+     * @test
+     */
+    public function GeneratedTraceIdIsNotNull()
+    {
+        $idGenerator = new AwsXrayIdGenerator();
+        $traceId = $idGenerator->generateTraceId();
+
+        $this->assertNotNull($traceId);
+    }
+
+    /**
+     * @test
+     */
+    public function GeneratedTraceIdTimeStampIsCurrent()
+    {
+        $idGenerator = new AwsXrayIdGenerator();
+        $prevTime = time();
+        $traceId1 = $idGenerator->generateTraceId();
+        $currTime = hexdec(substr($traceId1, 0, 8));
+        $nextTime = time();
+
+        $this->assertGreaterThanOrEqual($prevTime, $currTime);
+        $this->assertLessThanOrEqual($nextTime, $currTime);
+    }
+
+    /**
+     * @test
+     */
+    public function generatedSpanIdIsValid()
+    {
+        $idGenerator = new AwsXrayIdGenerator();
+        $spanId = $idGenerator->generateSpanId();
+
+        $this->assertEquals(1, preg_match(SpanContext::VALID_SPAN, $spanId));
+    }
+}

--- a/tests/unit/PropagatorTest.php
+++ b/tests/unit/PropagatorTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\Sdk\Trace\PropagationMap;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
+use PHPUnit\Framework\TestCase;
+use Propagators\Aws\Xray\AwsXrayPropagator;
+
+class AwsXrayPropagatorTest extends TestCase
+{
+    private const VERSION_NUMBER = '1';
+    private const TRACE_ID = '5759e988bd862e3fe1be46a994272793';
+    private const TRACE_ID_TIMESTAMP = '5759e988';
+    private const TRACE_ID_RANDOMHEX = 'bd862e3fe1be46a994272793';
+    private const SPAN_ID = '53995c3f42cd8ad8';
+    private const IS_SAMPLED = '1';
+    private const NOT_SAMPLED = '0';
+    private const TRACE_ID_HEADER_SAMPLED = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1';
+    private const TRACE_ID_HEADER_NOT_SAMPLED = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0';
+
+    /**
+     * @test
+     * fields() should return an array of fields with AWS X-Ray Trace ID Header
+     */
+    public function TestFields()
+    {
+        $propagator = new AwsXrayPropagator();
+        $this->assertSame(AwsXrayPropagator::fields(), [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER]);
+    }
+
+    /**
+     * @test
+     * Injects with a valid traceId, spanId, and is sampled
+     * restore(string $traceId, string $spanId, bool $sampled = false, bool $isRemote = false, ?API\TraceState $traceState = null): SpanContext
+     */
+    public function InjectValidSampledTraceId()
+    {
+        $carrier = [];
+        $map = new PropagationMap();
+        $context = SpanContext::restore(self::TRACE_ID, self::SPAN_ID, true, false);
+        AwsXrayPropagator::inject($context, $carrier, $map);
+
+        $this->assertSame(self::TRACE_ID_HEADER_SAMPLED, $map->get($carrier, AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER));
+    }
+
+    /**
+     * @test
+     * Injects with a valid traceId, spanId, and is not sampled
+     */
+    public function InjectValidNotSampledTraceId()
+    {
+        $carrier = [];
+        $map = new PropagationMap();
+        $context = SpanContext::restore(self::TRACE_ID, self::SPAN_ID, false, false);
+        AwsXrayPropagator::inject($context, $carrier, $map);
+
+        $this->assertSame(self::TRACE_ID_HEADER_NOT_SAMPLED, $map->get($carrier, AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER));
+    }
+
+    /**
+     * @test
+     * Test inject with tracestate
+     */
+    public function InjectTraceIdWithTraceState()
+    {
+        $carrier = [];
+        $map = new PropagationMap();
+        $tracestate = new TraceState('vendor1=opaqueValue1');
+        $context = SpanContext::restore(self::TRACE_ID, self::SPAN_ID, true, false, $tracestate);
+        AwsXrayPropagator::inject($context, $carrier, $map);
+
+        $this->assertSame(self::TRACE_ID_HEADER_SAMPLED, $map->get($carrier, AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER));
+    }
+
+    /**
+     * @test
+     * Test with an invalid spanContext, should return null
+     */
+    public function InjectTraceIdWithInvalidSpanContext()
+    {
+        $carrier = [];
+        $map = new PropagationMap();
+        $context = SpanContext::restore(SpanContext::INVALID_TRACE, SpanContext::INVALID_SPAN, true, false);
+        AwsXrayPropagator::inject($context, $carrier, $map);
+
+        $this->assertNull($map->get($carrier, AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER));
+    }
+
+    /**
+     * @test
+     * Test sampled, not sampled, extra fields, arbitrary order
+     */
+    public function ExtractValidSampledContext()
+    {
+        $traceHeaders = ['Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1',
+        'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0',
+        'Root=1-5759e988-bd862e3fe1be46a994272793;Foo=Bar;Parent=53995c3f42cd8ad8;Sampled=0', ];
+
+        foreach ($traceHeaders as $traceHeader) {
+            $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+            $map = new PropagationMap();
+            $context = AwsXrayPropagator::extract($carrier, $map);
+
+            $this->assertSame(self::TRACE_ID, $context->getTraceId());
+            $this->assertSame(self::SPAN_ID, $context->getSpanId());
+            $this->assertSame(substr($traceHeader, -1), ($context->isSampled() ? '1' : '0'));
+            $this->assertTrue($context->isRemote());
+        }
+    }
+
+    /**
+     * @test
+     * Test arbitrary order
+     */
+    public function ExtractValidSampledContextAbitraryOrder()
+    {
+        $traceHeader = 'Parent=53995c3f42cd8ad8;Sampled=1;Root=1-5759e988-bd862e3fe1be46a994272793';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(self::TRACE_ID, $context->getTraceId());
+        $this->assertSame(self::SPAN_ID, $context->getSpanId());
+        $this->assertSame(self::IS_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertTrue($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Must have '-' and not other delimiters
+     */
+    public function ExtractInvalidTraceIdDelimiter()
+    {
+        $traceHeader = 'Root=1*5759e988*bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Should return invalid spanContext
+     */
+    public function ExtractEmptySpanContext()
+    {
+        $traceHeader = '';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test different invalidSpanContexts
+     */
+    public function ExtractInvalidSpanContext()
+    {
+        $traceHeaders = [' ', 'abc-def-hig', '123abc'];
+
+        foreach ($traceHeaders as $traceHeader) {
+            $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+            $map = new PropagationMap();
+            $context = AwsXrayPropagator::extract($carrier, $map);
+
+            $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+            $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+            $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+            $this->assertFalse($context->isRemote());
+        }
+    }
+
+    /**
+     * @test
+     * Test Invalid Trace Id
+     */
+    public function ExtractInvalidTraceId()
+    {
+        $traceHeader = 'Root=1-00000000-000000000000000000000000;Parent=53995c3f42cd8ad8;Sampled=1';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test Invalid Trace Id Length
+     */
+    public function ExtractInvalidTraceIdLength()
+    {
+        $traceHeader = 'Root=1-5759e98s46v8-bd862e3fe1frbe46a994272793;Parent=53995c3f42cd8ad8;Sampled=1';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test Invalid Span Id
+     */
+    public function ExtractInvalidSpanId()
+    {
+        $traceHeader = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=0000000000000000;Sampled=1';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test Invalid Span Id
+     */
+    public function ExtractInvalidSpanIdLength()
+    {
+        $traceHeader = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad85dg;Sampled=1';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test null sample value
+     */
+    public function ExtractNullSampledValue()
+    {
+        $traceHeader = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test invalid sample value
+     */
+    public function ExtractInvalidSampleValue()
+    {
+        $traceHeader = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=12345';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+
+    /**
+     * @test
+     * Test incorrect xray version
+     */
+    public function ExtractInvalidXrayVersion()
+    {
+        $traceHeader = 'Root=2-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=12345';
+
+        $carrier = [AwsXrayPropagator::AWSXRAY_TRACE_ID_HEADER => $traceHeader];
+        $map = new PropagationMap();
+        $context = AwsXrayPropagator::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::NOT_SAMPLED, ($context->isSampled() ? '1' : '0'));
+        $this->assertFalse($context->isRemote());
+    }
+}


### PR DESCRIPTION
This PR addresses 3 main issues:

- OTEL Core Dependency
- AWS X-Ray ID Generator
- AWS X-Ray Propagator

Core dependency adds the core OTEL PHP repository to the vendor folder through the altered code in composer.json

The ID Generator generates trace Ids in AWS X-Ray format. More information is within comments in the code. 

The AWS X-Ray propagator conforms to TextMapFormat and propagates trace headers in AWS X-Ray format. 

@alolita @Aneurysm9 