### PR TITLE
Add ECS Resource Detector

### DIFF
--- a/detectors/aws/EcsDetector.php
+++ b/detectors/aws/EcsDetector.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Detectors\Aws;
+
+use OpenTelemetry\Sdk\Resource\ResourceConstants;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attributes;
+
+/**
+ * The AwsEcsDetector can be used to detect if a process is running in AWS
+ * ECS and return a {@link Resource} populated with data about the ECS
+ * plugins of AWS ˜X-Ray. Returns an empty Resource if detection fails.
+ */
+class EcsDetector
+{
+    private const ECS_METADATA_KEY_V4 = 'ECS_CONTAINER_METADATA_URI_V4';
+    private const ECS_METADATA_KEY_V3 = 'ECS_CONTAINER_METADATA_URI';
+
+    private const CONTAINER_ID_LENGTH = 64;
+
+    public function __construct(EcsProcessDataProvider $processData)
+    {
+        $this->processData = $processData;
+    }
+    
+    /**
+     * If running on ECS, runs getContainerId(), getClusterName(), and
+     * returns resource with valid extracted values
+     * If not running on ECS, returns empty rsource
+     */
+    public function detect(): ResourceInfo
+    {
+        // Check if running on ECS by looking for below environment variables
+        if (!getenv(self::ECS_METADATA_KEY_V4) && !getenv(self::ECS_METADATA_KEY_V3)) {
+            // TODO: add 'Process is not running on ECS' when logs are added
+            return ResourceInfo::emptyResource();
+        }
+
+        $hostName = $this->processData->getHostname();
+        $containerId = $this->getContainerId();
+
+        return !$hostName && !$containerId
+            ? ResourceInfo::emptyResource()
+            : ResourceInfo::create(new Attributes([
+                ResourceConstants::CONTAINER_NAME => $hostName,
+                ResourceConstants::CONTAINER_ID => $containerId,
+            ]));
+    }
+
+    /**
+     * Returns the docker ID of the container found
+     * in its CGroup file.
+     */
+    private function getContainerId()
+    {
+        try {
+            $cgroupData = $this->processData->getCgroupData();
+
+            if (!$cgroupData) {
+                return null;
+            }
+
+            foreach ($cgroupData as $str) {
+                if (strlen($str) > self::CONTAINER_ID_LENGTH) {
+                    return substr($str, strlen($str) - self::CONTAINER_ID_LENGTH);
+                }
+            }
+        } catch (Exception $e) {
+            //TODO: add 'Failed to read container ID' when logging is added
+        }
+
+        return null;
+    }
+}
+
+/**
+ * Separated from above class to be able to test using
+ * mock values through unit tests
+ */
+class EcsProcessDataProvider
+{
+    private const DEFAULT_CGROUP_PATH = '/proc/self/cgroup';
+
+    /**
+     * Returns the host name of the container the process is in.
+     * This would be the os the container is running on,
+     * i.e. the platform on which it is deployed
+     */
+    public function getHostName()
+    {
+        return php_uname('n');
+    }
+    
+    /**
+     * Get data from the Cgroup file
+     */
+    public function getCgroupData()
+    {
+        return file(self::DEFAULT_CGROUP_PATH, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    }
+}

--- a/tests/unit/EcsDetectorTest.php
+++ b/tests/unit/EcsDetectorTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+use Detectors\Aws\EcsDetector;
+use Detectors\Aws\EcsProcessDataProvider;
+use OpenTelemetry\Sdk\Resource\ResourceConstants;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use PHPUnit\Framework\TestCase;
+
+class EcsDetectorTest extends TestCase
+{
+    private const VALID_CGROUP_DATA = ['abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm', '', 'abcdefghijk'];
+    private const MULTIVALID_CGROUP_DATA = ['abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm',
+                                            'bbbbjklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm', 'abcdefghijk', ];
+    private const INVALID_CGROUP_LENGTH = ['abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl', 'abcdefghijk',' '];
+    private const INVALID_CGROUP_EMPTY = []; // empty
+    private const INVALID_CGROUP_VALUES = ['','','']; // empty
+
+    private const HOST_NAME = 'abcd.test.testing.com';
+
+    private const EXTRACTED_CONTAINER_ID = 'bcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm';
+
+    private const ECS_ENV_VAR_V4_KEY = 'ECS_CONTAINER_METADATA_URI_V4';
+    private const ECS_ENV_VAR_V3_KEY = 'ECS_CONTAINER_METADATA_URI';
+    private const ECS_ENV_VAR_V4_VAL = 'ecs_metadata_v4_uri';
+    private const ECS_ENV_VAR_V3_VAL = 'ecs_metadata_v3_uri';
+
+    /**
+     * @test
+     */
+    public function TestValidCgroupData()
+    {
+        putenv(self::ECS_ENV_VAR_V4_KEY . '=' . self::ECS_ENV_VAR_V4_VAL);
+
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getHostName')->willReturn(self::HOST_NAME);
+
+        $detector = new EcsDetector($mockData);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_NAME => self::HOST_NAME,
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                ]
+            )
+        ), $detector->detect());
+
+        //unset environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY);
+    }
+    
+    /**
+     * @test
+     */
+    public function TestFirstValidCgroupData()
+    {
+        putenv(self::ECS_ENV_VAR_V4_KEY . '=' . self::ECS_ENV_VAR_V4_VAL);
+
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::MULTIVALID_CGROUP_DATA);
+        $mockData->method('getHostName')->willReturn(self::HOST_NAME);
+
+        $detector = new EcsDetector($mockData);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_NAME => self::HOST_NAME,
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                ]
+            )
+        ), $detector->detect());
+
+        //unset environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY);
+    }
+
+    /**
+     * @test
+     */
+    public function TestIsRunningOnEcsReturnsEmpty()
+    {
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::MULTIVALID_CGROUP_DATA);
+        $mockData->method('getHostName')->willReturn(self::HOST_NAME);
+
+        $detector = new EcsDetector($mockData);
+
+        $this->assertEquals(ResourceInfo::emptyResource(), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestReturnOnlyHostnameWithoutCgroupFile()
+    {
+        // Test other version (v3)
+        putenv(self::ECS_ENV_VAR_V3_KEY . '=' . self::ECS_ENV_VAR_V3_VAL);
+
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(false);
+        $mockData->method('getHostName')->willReturn(self::HOST_NAME);
+
+        $detector = new EcsDetector($mockData);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_NAME => self::HOST_NAME,
+                ]
+            )
+        ), $detector->detect());
+
+        //unset environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY);
+    }
+
+    /**
+     * @test
+     */
+    public function TestReturnOnlyHostnameWithInvalidCgroupFile()
+    {
+        // Test other version (v3)
+        putenv(self::ECS_ENV_VAR_V4_KEY . '=' . self::ECS_ENV_VAR_V4_VAL);
+
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+        $mockData->method('getHostName')->willReturn(self::HOST_NAME);
+
+        $detector = new EcsDetector($mockData);
+      
+        $invalidCgroups = [self::INVALID_CGROUP_LENGTH, self::INVALID_CGROUP_EMPTY, self::INVALID_CGROUP_VALUES];
+
+        foreach ($invalidCgroups as $invalidCgroup) {
+            $mockData->method('getCgroupData')->willReturn($invalidCgroup);
+
+            $this->assertEquals(ResourceInfo::create(
+                new Attributes(
+                    [
+                        ResourceConstants::CONTAINER_NAME => self::HOST_NAME,
+                    ]
+                )
+            ), $detector->detect());
+        }
+
+        //unset environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY);
+    }
+
+    /**
+     * @test
+     */
+    public function TestReturnOnlyContainerIdWithoutHostname()
+    {
+        putenv(self::ECS_ENV_VAR_V4_KEY . '=' . self::ECS_ENV_VAR_V4_VAL);
+
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getHostName')->willReturn(null);
+
+        $detector = new EcsDetector($mockData);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                ]
+            )
+        ), $detector->detect());
+
+        //unset environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY);
+    }
+
+    /**
+     * @test
+     */
+    public function TestReturnEmptyResourceInvalidContainerIdAndHostname()
+    {
+        // Set environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY . '=' . self::ECS_ENV_VAR_V4_VAL);
+
+        $mockData = $this->createMock(EcsProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_LENGTH);
+        $mockData->method('getHostName')->willReturn(null);
+        
+        $detector = new EcsDetector($mockData);
+
+        $this->assertEquals(ResourceInfo::emptyResource(), $detector->detect());
+
+        // Unset environment variable
+        putenv(self::ECS_ENV_VAR_V4_KEY);
+    }
+}


### PR DESCRIPTION
This PR adds the ECS detector:

The ECS detector looks for one of the two environment variables and populates and returns a resource with the container ID and hostName if available/succeeds. The ECS detector is split up into two classes since mock testing cannot be achieved otherwise. 

A PR in the core repo will be created to add the CONTAINER_ID as a resource constant as an ID is something that exists quite often. A comment is in the code left as a TODO.

Currently the PHP Library has no Logging so comments were left in as TODOs for future development if logging is added. 


@alolita @Aneurysm9 @lupengamzn 