### PR TITLE
Add EKS Resource Detector

### DIFF
--- a/detectors/aws/EksDetector.php
+++ b/detectors/aws/EksDetector.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Detectors\Aws;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use OpenTelemetry\Sdk\Resource\ResourceConstants;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attributes;
+
+/**
+ * The AwsEksDetector can be used to detect if a process is running in AWS
+ * Elastic Kubernetes and return a {@link Resource} populated with data about the Kubernetes
+ * plugins of AWS X-Ray. Returns an empty Resource if detection fails.
+ */
+class EksDetector
+{
+    // Credentials and path for locating API
+    private const K8S_SVC_URL = 'kubernetes.default.svc';
+    private const K8S_CERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
+
+    // Path for Amazon CloudWatch Logs
+    private const AUTH_CONFIGMAP_PATH = '/api/v1/namespaces/kube-system/configmaps/aws-auth';
+    private const CW_CONFIGMAP_PATH = '/api/v1/namespaces/amazon-cloudwatch/configmaps/cluster-info';
+
+    private const CONTAINER_ID_LENGTH = 64;
+
+    private EksProcessDataProvider $processData;
+    private Client $guzzle;
+    
+    public function __construct(EksProcessDataProvider $processData, Client $guzzle)
+    {
+        $this->processData = $processData;
+        $this->guzzle = $guzzle;
+    }
+    
+    public function detect(): ResourceInfo
+    {
+        try {
+            if (!$this->processData->isK8s() || !$this->isEks()) {
+                return ResourceInfo::emptyResource();
+            }
+
+            $clusterName = $this->getClusterName();
+            $containerId = $this->getContainerId();
+    
+            return !$clusterName && !$containerId
+                ? ResourceInfo::emptyResource()
+                : ResourceInfo::create(new Attributes([
+                    ResourceConstants::CONTAINER_ID => $containerId,
+                    ResourceConstants::K8S_CLUSTER_NAME => $clusterName,
+                ]));
+        } catch (\Throwable $e) {
+            //TODO: add 'Process is not running on K8S when logging is added
+            return ResourceInfo::emptyResource();
+        }
+    }
+
+    private function getContainerId()
+    {
+        try {
+            $cgroupData = $this->processData->getCgroupData();
+
+            if (!$cgroupData) {
+                return null;
+            }
+
+            foreach ($cgroupData as $str) {
+                if (strlen($str) > self::CONTAINER_ID_LENGTH) {
+                    return substr($str, strlen($str) - self::CONTAINER_ID_LENGTH);
+                }
+            }
+        } catch (\Throwable $e) {
+            //TODO: add 'Failed to read container ID' when logging is added
+            return null;
+        }
+    }
+
+    public function getClusterName()
+    {
+        // Create a request to AWS Config map which determines
+        // whether the process is running on an EKS
+        $client = $this->guzzle;
+
+        try {
+            $response = $client->request(
+                'GET',
+                'https://' . self::K8S_SVC_URL . self::CW_CONFIGMAP_PATH,
+                [
+                    'headers' => [
+                        'Authorization' => $this->processData->getK8sHeader() . ', Bearer ' . self::K8S_CERT_PATH,
+                    ],
+                    'timeout' => 2000,
+                ]
+            );
+
+            $json = json_decode($response->getBody()->getContents(), true);
+
+            if (isset($json['data']['cluster.name'])) {
+                return $json['data']['cluster.name'];
+            }
+
+            return null;
+        } catch (RequestException $e) {
+            // TODO: add log for exception. The code below
+            // provides the exception thrown:
+            // echo Psr7\Message::toString($e->getRequest());
+            // if ($e->hasResponse()) {
+            //     echo Psr7\Message::toString($e->getResponse());
+            // }
+            return null;
+        }
+    }
+
+    // Create a request to AWS Config map which determines
+    // whether the process is running on an EKS
+    public function isEks()
+    {
+        $client = $this->guzzle;
+
+        try {
+            $response = $client->request(
+                'GET',
+                'https://' . self::K8S_SVC_URL . self::AUTH_CONFIGMAP_PATH,
+                [
+                    'headers' => [
+                        'Authorization' => $this->processData->getK8sHeader() . ', Bearer ' . self::K8S_CERT_PATH,
+                    ],
+                    'timeout' => 2000,
+                ]
+            );
+
+            $body = $response->getBody()->getContents();
+            $responseCode = $response->getStatusCode();
+
+            return !empty($body) && $responseCode < 300 && $responseCode >= 200;
+        } catch (RequestException $e) {
+            // TODO: add log for exception. The code below
+            // provides the exception thrown:
+            // echo Psr7\Message::toString($e->getRequest());
+            // if ($e->hasResponse()) {
+            //     echo Psr7\Message::toString($e->getResponse());
+            // }
+
+            return false;
+        }
+    }
+}
+
+/**
+ * Separated from above class to be able to test using
+ * mock values through unit tests
+ */
+class EksProcessDataProvider
+{
+    private const DEFAULT_CGROUP_PATH = '/proc/self/cgroup';
+    private const K8S_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+    private const K8S_CERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
+
+    public function getK8sHeader()
+    {
+        $credHeader = file_get_contents(self::K8S_TOKEN_PATH);
+        
+        if ($credHeader) {
+            return 'Bearer' . $credHeader;
+        }
+
+        //TODO: Add log 'Unable to load K8s client token'
+        return null;
+    }
+
+    // Check if there exists a k8s certification file
+    public function isK8s()
+    {
+        return file_get_contents(self::K8S_CERT_PATH);
+    }
+
+    public function getCgroupData()
+    {
+        return file(self::DEFAULT_CGROUP_PATH, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    }
+}

--- a/tests/unit/EksDetectorTest.php
+++ b/tests/unit/EksDetectorTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+use Detectors\Aws\EksDetector;
+use Detectors\Aws\EksProcessDataProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use OpenTelemetry\Sdk\Resource\ResourceConstants;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use PHPUnit\Framework\TestCase;
+
+class EksDetectorTest extends TestCase
+{
+    private const VALID_CGROUP_DATA = ['abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm', '', 'abcdefghijk'];
+    private const INVALID_CGROUP_LENGTH = ['abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl', 'abcdefghijk',' '];
+    private const INVALID_CGROUP_EMPTY = [];
+    private const INVALID_CGROUP_VALUES = ['','',''];
+
+    private const MOCK_VALID_CLUSTER_RESPONSE = '{"data":{"cluster.name":"my-cluster"}}';
+    private const MOCK_EMPTY_CLUSTER_NAME = '{"data": "empty"}';
+    private const MOCK_EMPTY_CLUSTER_DATA = '{"test": "empty"}';
+    private const MOCK_EMPTY_BODY = '';
+    private const MOCK_AWS_AUTH = 'my-auth';
+    private const MOCK_K8S_TOKEN = 'Bearer 31ada4fd-adec-460c-809a-9e56ceb75269';
+
+    private const EXTRACTED_CONTAINER_ID = 'bcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm';
+    private const EXTRACTED_CLUSTER_NAME = 'my-cluster';
+
+    /**
+     * @test
+     */
+    public function TestValidKubernetes()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                    ResourceConstants::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
+                ]
+            )
+        ), $detector->detect());
+    }
+    
+    /**
+     * @test
+     */
+    public function TestValidClusterNameInvalidContainerId()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_VALUES);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
+                ]
+            )
+        ), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestValidClusterNameEmptyContainerId()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_EMPTY);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
+                ]
+            )
+        ), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestValidClusterNameShortContainerId()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_LENGTH);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
+                ]
+            )
+        ), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestValidContianerIdEmptyClusterName()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_CLUSTER_NAME),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                ]
+            )
+        ), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestValidContianerIdEmptyData()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_CLUSTER_DATA),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                ]
+            )
+        ), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestValidContianerIdEmptyBody()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_BODY),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::create(
+            new Attributes(
+                [
+                    ResourceConstants::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
+                ]
+            )
+        ), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestInvalidBodyIsEks()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(300, ['Foo' => 'Bar'], self::MOCK_EMPTY_BODY),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::emptyResource(), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestInvalidResponseCode()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::VALID_CGROUP_DATA);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(300, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::emptyResource(), $detector->detect());
+    }
+    
+    /**
+     * @test
+     */
+    public function TestInvalidContainerIdAndClusterName()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_VALUES);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(self::MOCK_AWS_AUTH);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_BODY),
+
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::emptyResource(), $detector->detect());
+    }
+
+    /**
+     * @test
+     */
+    public function TestInvalidisKubernetesFile()
+    {
+        $mockData = $this->createMock(EksProcessDataProvider::class);
+
+        $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_VALUES);
+        $mockData->method('getK8sHeader')->willReturn(self::MOCK_K8S_TOKEN);
+        $mockData->method('isK8s')->willReturn(false);
+
+        $mockGuzzle = new MockHandler([
+            new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
+        ]);
+        
+        $handlerStack = HandlerStack::create($mockGuzzle);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $detector = new EksDetector($mockData, $client);
+
+        $this->assertEquals(ResourceInfo::emptyResource(), $detector->detect());
+    }
+}


### PR DESCRIPTION
This PR adds the EKS detector:

The EKS detector looks at some certification files and creates some requests to verify the application is running on EKS. If it is it will look for the containerId and cluster name. Otherwise it will return an empty resource

Currently the PHP Library has no Logging so comments were left in as TODOs for future development if logging is added.

@alolita @Aneurysm9 @lupengamzn